### PR TITLE
3 false drop identification and codification

### DIFF
--- a/Conciliation/Pre-experiment/02_Code/01_R/01_clean_conciliation.R
+++ b/Conciliation/Pre-experiment/02_Code/01_R/01_clean_conciliation.R
@@ -144,7 +144,7 @@ comparecientes <- comparecientes %>%
   distinct(parte_id,audiencia_id, .keep_all = TRUE) %>%
   select("audiencia_id","parte_id","presentado") 
 
-worker_request_fake_drops <- left_join(hearings_features,comparecientes, by=c("audiencia_id","parte_id")) %>%
+hearings_features <- left_join(hearings_features,comparecientes, by=c("audiencia_id","parte_id")) %>%
   mutate(presentado=if_else(is.na(presentado),0,if_else(presentado==1,1,NA))) %>%
   mutate(citado_trabajador_comparece=if_else(is.na(citado_trabajador_comparece),1,citado_trabajador_comparece))  
 

--- a/Conciliation/Pre-experiment/02_Code/01_R/02_false_drop_identification.R
+++ b/Conciliation/Pre-experiment/02_Code/01_R/02_false_drop_identification.R
@@ -57,5 +57,33 @@ final_base <- left_join(hearings_features,worker_hearing_request_characteristics
 # The possibility of a mistmath is confusing, as there should be data for every worker. 
 # But remember on 01_clean_conciliation we winsorized workers data.
 
+# -----------------------------------------------------------------------------
+#                               Identification
+# -----------------------------------------------------------------------------
+
+# To identify a false drop, it is necessary to have the curp of the worker, as it is the only intifier that lets us know if 
+# a worker went twice to the conciliaiton center 
+
+# filtering for curp 
+final_base <- final_base %>%
+  filter(!is.na(curp_trabajador))
+
+# prelimnar count of worker repetition on the data set 
+final_base <- final_base %>%
+  group_by(curp_trabajador) %>%
+  mutate(cuanto_repiten_curp_trabajador=n()) %>%
+  ungroup() %>%
+  group_by(rfc_trabajador) %>%
+  mutate(cuanto_repiten_rfc_trabajador=n()) %>%
+  ungroup() 
+
+# is this curp repeated somewhere in the data set dummy
+final_base <- final_base %>%
+  mutate(curp_repetido=if_else(cuanto_repiten_curp_trabajador>1,1,0))
+
+#  number of cases where we have a worker that came more than once (take into account that they are counting double or tripple
+# , the data is at the level hearing so every hearing where I "Antonio" came to the heraing counts as once observation)
+
+ table(final_base$curp_repetido)
 
 

--- a/Conciliation/Pre-experiment/02_Code/01_R/02_false_drop_identification.R
+++ b/Conciliation/Pre-experiment/02_Code/01_R/02_false_drop_identification.R
@@ -184,5 +184,8 @@ final_base <- final_base %>%
    mutate(diff_con_asump_time_25_dropped=if_else(false_drop_time_25_dropped==0,0,different_conciliator)) %>% 
    mutate(presentado_25_dropped=if_else(false_drop_time_25_dropped==0,presentado,presentado_next_claim))
  
-
+# write 
+ write.csv( final_base,here("01_Data",
+                              "02_Created",
+                              "base_with_fake_drops.csv"))
  

--- a/Conciliation/Pre-experiment/02_Code/01_R/02_false_drop_identification.R
+++ b/Conciliation/Pre-experiment/02_Code/01_R/02_false_drop_identification.R
@@ -135,9 +135,15 @@ final_base <- final_base %>%
    mutate(max_no_hubo_convenio_next_claim=lead(max_no_hubo_convenio))%>%
    mutate(max_numero_audiencia_next_claim=lead(max_numero_audiencia))%>%
    # leading information about summoned and atendance to the hearings
+   mutate(presentado_next_claim=lead(presentado))%>%
    mutate(citados_comparecen_audiencia_next_claim=lead(citados_comparecen_audiencia))%>%
    mutate(diferencia_citados_comaprecientes_next_claim=lead(diferencia_citados_comaprecientes))%>%
    ungroup()
+ 
+# creating a variable that denotes if the conciliator changed 
+ final_base <-  final_base %>%
+   mutate(different_conciliator=if_else(conciliador_next_claim!=conciliador,1,0))
+ 
  
  # -----------------------------------------------------------------------------
  #                              Using lead infromation to compute false drops
@@ -161,6 +167,22 @@ final_base <- final_base %>%
    mutate(false_drop_time_25_dropped=if_else(tiempo_entre_audiencia_y_siguiente_solicitud<=25 &
                                                max_archivado==1 &
                                                tiempo_entre_audiencia_y_siguiente_solicitud>=0,1,0)) 
+ 
+# It is not enough to identify false drops; to conduct any worthwhile analysis, we need other variables—controls or outcomes.
+# We ensured this by previously leading with other variables; however, for all observations that are not
+# false drops we need to keep the old value 
+ 
+ final_base <-  final_base %>%
+   # If the observation is a false drop, put the next claim, if not put the same claim
+   mutate(numero_citados_asump_time_25=if_else(false_drop_time_25_dropped==0,numero_citados,numero_citados_next_claim))%>%
+   mutate(max_hubo_convenio_asump_time_25=if_else(false_drop_time_25_dropped==0,max_hubo_convenio,max_hubo_convenio_next_claim))%>%
+   mutate(max_no_hubo_convenio_asump_time_25=if_else(false_drop_time_25_dropped==0,max_no_hubo_convenio,max_no_hubo_convenio_next_claim))%>%
+   mutate(max_numero_audiencia_asump_time_25=if_else(false_drop_time_25_dropped==0,max_numero_audiencia,max_numero_audiencia_next_claim))%>%
+   mutate(max_archivado_asump_time_25=if_else(false_drop_time_25_dropped==0,max_archivado,max_archivado_next_claim))%>%
+   mutate(citados_comparecen_audiencia_asump_time_25=if_else(false_drop_time_25_dropped==0,citados_comparecen_audiencia,citados_comparecen_audiencia_next_claim))%>%
+   mutate(diferencia_citados_comaprecientes_asump_time_25=if_else(false_drop_time_25_dropped==0,diferencia_citados_comaprecientes,diferencia_citados_comaprecientes_next_claim))%>%
+   mutate(diff_con_asump_time_25_dropped=if_else(false_drop_time_25_dropped==0,0,different_conciliator)) %>% 
+   mutate(presentado_25_dropped=if_else(false_drop_time_25_dropped==0,presentado,presentado_next_claim))
  
 
  

--- a/Conciliation/Pre-experiment/02_Code/01_R/02_false_drop_identification.R
+++ b/Conciliation/Pre-experiment/02_Code/01_R/02_false_drop_identification.R
@@ -1,0 +1,37 @@
+# -----------------------------------------------------------------------------
+#                              Conciliation project
+# 
+# Code author: Antonio Carbonell
+# Date: August 28, 2024
+#
+# Code modifications: 
+# Date of modifications:
+#
+# Objective: Identify false drops 
+#
+# Data inputs: worker_first, worker_hearing_request_characteristics
+# Outputs: final_base
+# -----------------------------------------------------------------------------
+
+# -----------------------------------------------------------------------------
+#                           Libraries and settings
+# -----------------------------------------------------------------------------
+if (!require("pacman")) {
+  install.packages("pacman")
+}
+
+pacman::p_load(here, tidyverse, fixest, knitr, kableExtra, vtable, haven, RCT)
+
+# -----------------------------------------------------------------------------
+#                               Read in datasets
+# -----------------------------------------------------------------------------
+
+
+hearings_features <- read.csv(here("01_Data",
+                                   "02_Created",
+                                   "worker_first.csv"))
+
+
+worker_hearing_request_characteristics <-  read_csv(here("01_Data",
+                                                          "02_Created",
+                                                          "worker_hearing_request_characteristics.csv.csv"))

--- a/Conciliation/Pre-experiment/02_Code/01_R/02_false_drop_identification.R
+++ b/Conciliation/Pre-experiment/02_Code/01_R/02_false_drop_identification.R
@@ -34,4 +34,28 @@ hearings_features <- read.csv(here("01_Data",
 
 worker_hearing_request_characteristics <-  read_csv(here("01_Data",
                                                           "02_Created",
-                                                          "worker_hearing_request_characteristics.csv.csv"))
+                                                          "worker_hearing_request_characteristics.csv"))
+
+# -----------------------------------------------------------------------------
+#                               Merge data sets
+# -----------------------------------------------------------------------------
+
+# Observations before merge 
+# hearing features: 31822
+# worker_hearing_request_characteristics: 103394
+
+# level of the data
+# hearing features: first hearing-one worker-request
+# worker_hearing_request_characteristics: worker-hearing-request
+
+final_base <- left_join(hearings_features,worker_hearing_request_characteristics,  by=c("solicitud_id","audiencia_id","parte_id"))
+
+# final base merge:
+# Observations matched: 29848
+# Observations not matched 1974
+
+# The possibility of a mistmath is confusing, as there should be data for every worker. 
+# But remember on 01_clean_conciliation we winsorized workers data.
+
+
+


### PR DESCRIPTION
To solve the problem, false drops were identified using two criteria: the first is that a request was made within less than 25 days after the last hearing; the second is that the first hearing ended in a case closure. Additionally, some data were lead that will be useful for performing regressions and other relevant analyses. The outcome of this script is, therefore, a dataset that combines the worker's characteristics, those of the hearing, and the identification of false drops.